### PR TITLE
Add TableOfNAME support

### DIFF
--- a/src/WaterTrans.GlyphLoader/Internal/NAME/NameEncoding.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/NAME/NameEncoding.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Text;
+
+namespace WaterTrans.GlyphLoader.Internal.NAME
+{
+    /// <summary>
+    /// NAME NameRecord name string encoding.
+    /// </summary>
+    internal class NameEncoding
+    {
+        internal static Encoding GetEncoding(NameRecord record)
+        {
+            try
+            {
+                switch (record.PlatformID)
+                {
+                    case (ushort) PlatformID.Unicode:
+                        return Encoding.BigEndianUnicode;
+                    case (ushort) PlatformID.Macintosh:
+                        switch (record.EncodingID)
+                        {
+                            case 0: return Encoding.ASCII;
+                            case 1: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-japanese"); //return Encoding.GetEncoding("x-mac-japanese");
+                            case 2: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-chinesetrad"); //return Encoding.GetEncoding("x-mac-chinesetrad");
+                            case 3: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-korean"); //return Encoding.GetEncoding("x-mac-korean");
+                            case 4: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-arabic"); //return Encoding.GetEncoding("x-mac-arabic");
+                            case 5: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-hebrew"); //return Encoding.GetEncoding("x-mac-hebrew");
+                            case 6: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-greek"); //return Encoding.GetEncoding("x-mac-greek");
+                            case 7: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-cyrillic"); //return Encoding.GetEncoding("x-mac-cyrillic");
+                            //case 8: return Encoding.GetEncoding("");
+                            case 9: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-de"); //return Encoding.GetEncoding("x-iscii-de");
+                            //case 10: return Encoding.GetEncoding("");
+                            case 11: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-gu"); //return Encoding.GetEncoding("x-iscii-gu");
+                            case 12: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-or"); //return Encoding.GetEncoding("x-iscii-or");
+                            case 13: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-be"); //return Encoding.GetEncoding("x-iscii-be");
+                            case 14: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-ta"); //return Encoding.GetEncoding("x-iscii-ta");
+                            case 15: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-te"); //return Encoding.GetEncoding("x-iscii-te");
+                            case 16: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-ka"); //return Encoding.GetEncoding("x-iscii-ka");
+                            case 17: return CodePagesEncodingProvider.Instance.GetEncoding("x-iscii-ma"); //return Encoding.GetEncoding("x-iscii-ma");
+                            //case 18: return Encoding.GetEncoding("");
+                            case 19: return CodePagesEncodingProvider.Instance.GetEncoding("Windows-1252"); //return Encoding.GetEncoding("Windows-1252");
+                            //case 20: return Encoding.GetEncoding("");
+                            case 21: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-thai"); //return Encoding.GetEncoding("x-mac-thai");
+                            //case 22: return Encoding.GetEncoding("");
+                            //case 23: return Encoding.GetEncoding("");
+                            //case 24: return Encoding.GetEncoding("");
+                            case 25: return CodePagesEncodingProvider.Instance.GetEncoding("x-mac-chinesesimp"); //return Encoding.GetEncoding("x-mac-chinesesimp");
+                            //case 26: return Encoding.GetEncoding("");
+                            //case 27: return Encoding.GetEncoding("");
+                            //case 28: return Encoding.GetEncoding("");
+                            //case 29: return Encoding.GetEncoding("");
+                            case 30: return CodePagesEncodingProvider.Instance.GetEncoding("windows-1258"); //return Encoding.GetEncoding("windows-1258");
+                            //case 31: return Encoding.GetEncoding("");
+                            //case 32: return Encoding.GetEncoding("");
+                        }
+
+                        break;
+                    case (ushort) PlatformID.ISO:
+                        switch (record.EncodingID)
+                        {
+                            case 0: return Encoding.ASCII;
+                            case 1: return Encoding.BigEndianUnicode;
+                            case 2: return Encoding.GetEncoding(1252);
+                        }
+
+                        break;
+                    case (ushort) PlatformID.Microsoft:
+                        switch (record.EncodingID)
+                        {
+                            case 1: return Encoding.BigEndianUnicode;
+                            case 2: return Encoding.GetEncoding("shift_jis");
+                            case 3: return Encoding.GetEncoding("gb2312");
+                            case 4: return Encoding.GetEncoding("big5");
+                            case 5: return Encoding.GetEncoding("x-cp20949");
+                            case 6: return Encoding.GetEncoding("Johab");
+                            case 10: return Encoding.BigEndianUnicode;
+                        }
+
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex.Message);
+                return Encoding.ASCII;
+            }
+
+            return Encoding.ASCII;
+        }
+    }
+}

--- a/src/WaterTrans.GlyphLoader/Internal/NAME/NameRecord.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/NAME/NameRecord.cs
@@ -1,0 +1,43 @@
+﻿namespace WaterTrans.GlyphLoader.Internal.NAME
+{
+    /// <summary>
+    /// The name records array item.
+    /// </summary>
+    internal sealed class NameRecord
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NameRecord"/> class.
+        /// </summary>
+        /// <param name="reader">The <see cref="TypefaceReader"/>.</param>
+        internal NameRecord(TypefaceReader reader)
+        {
+            PlatformID = reader.ReadUInt16();
+            EncodingID = reader.ReadUInt16();
+            LanguageID = reader.ReadUInt16();
+            NameID = reader.ReadUInt16();
+            Length = reader.ReadUInt16();
+            Offset = reader.ReadUInt16();
+        }
+
+        /// <summary>Platform identifier code.</summary>
+        public ushort PlatformID { get; }
+
+        /// <summary>Platform-specific encoding identifier.</summary>
+        public ushort EncodingID { get; }
+
+        /// <summary>Language identifier.</summary>
+        public ushort LanguageID { get; }
+
+        /// <summary>Name identifiers.</summary>
+        public ushort NameID { get; }
+
+        /// <summary>Name string length in bytes.</summary>
+        public ushort Length { get; }
+
+        /// <summary>Name string offset in bytes from stringOffset.</summary>
+        public ushort Offset { get; }
+
+        /// <summary>The character strings of the names. Note that these are not necessarily ASCII!</summary>
+        public string NameString { get; set; }
+    }
+}

--- a/src/WaterTrans.GlyphLoader/Internal/NAME/PlatformID.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/NAME/PlatformID.cs
@@ -1,0 +1,18 @@
+﻿namespace WaterTrans.GlyphLoader.Internal.NAME
+{
+    /// <summary>The NAME NameRecord PlatformID type enumeration.</summary>
+    internal enum PlatformID : ushort
+    {
+        /// <summary>Indicates Unicode version.</summary>
+        Unicode = 0,
+
+        /// <summary>QuickDraw Script Manager code.</summary>
+        Macintosh = 1,
+
+        /// <summary>(reserved; do not use)</summary>
+        ISO = 2,
+
+        /// <summary>Microsoft encoding.</summary>
+        Microsoft = 3
+    }
+}

--- a/src/WaterTrans.GlyphLoader/Internal/TableOfNAME.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/TableOfNAME.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WaterTrans.GlyphLoader.Internal.NAME;
+
+namespace WaterTrans.GlyphLoader.Internal
+{
+    /// <summary>
+    /// Table of NAME
+    /// </summary>
+    internal sealed class TableOfNAME
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableOfNAME"/> class.
+        /// </summary>
+        /// <param name="reader">The <see cref="TypefaceReader"/>.</param>
+        internal TableOfNAME(TypefaceReader reader)
+        {
+            var basePosition = reader.Position;
+            Format = reader.ReadUInt16();
+            NumberOfRecords = reader.ReadUInt16();
+            StringOffset = reader.ReadUInt16();
+            for (var i = 0; i < NumberOfRecords; i++)
+            {
+                NameRecords.Add(new NameRecord(reader));
+            }
+
+            foreach (var record in NameRecords)
+            {
+                reader.Position = basePosition + StringOffset + record.Offset;
+                record.NameString = reader.ReadString(record.Length, NameEncoding.GetEncoding(record));
+            }
+        }
+
+        /// <summary>Format selector. Set to 0.</summary>
+        public ushort Format { get; }
+
+        /// <summary>The number of nameRecords in this name table.</summary>
+        public ushort NumberOfRecords { get; }
+
+        /// <summary>Offset in bytes to the beginning of the name character strings.</summary>
+        public ushort StringOffset { get; }
+
+        /// <summary>Get a list of NameRecord.</summary>
+        public List<NameRecord> NameRecords { get; } = new List<NameRecord>();
+    }
+}

--- a/src/WaterTrans.GlyphLoader/Internal/TypefaceReader.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/TypefaceReader.cs
@@ -32,6 +32,18 @@ namespace WaterTrans.GlyphLoader.Internal
         public long Position { get; set; }
 
         /// <summary>
+        /// Read string.
+        /// </summary>
+        /// <param name="len">Number of length.</param>
+        /// <param name="encoding">Encoding</param>
+        /// <returns>Read result.</returns>
+        public string ReadString(int len, Encoding encoding)
+        {
+            var buf = ReadBytes(len);
+            return encoding.GetString(buf);
+        }
+
+        /// <summary>
         /// Read char array.
         /// </summary>
         /// <param name="len">Number of length.</param>

--- a/src/WaterTrans.GlyphLoader/Typeface.cs
+++ b/src/WaterTrans.GlyphLoader/Typeface.cs
@@ -54,6 +54,7 @@ namespace WaterTrans.GlyphLoader
         private TableOfGSUB _tableOfGSUB;
         private TableOfGPOS _tableOfGPOS;
         private TableOfCFF  _tableOfCFF;
+        private TableOfNAME _tableOfNAME;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Typeface"/> class.
@@ -924,6 +925,17 @@ namespace WaterTrans.GlyphLoader
             }
         }
 
+        private void ReadNAME(TypefaceReader reader)
+        {
+            if (!_tableDirectories.ContainsKey(TableNames.NAME))
+            {
+                return;
+            }
+
+            reader.Position = _tableDirectories[TableNames.NAME].Offset;
+            _tableOfNAME = new TableOfNAME(reader);
+        }
+
         private CharString ReadCFFCharString(ushort glyphIndex)
         {
             CharString result = null;
@@ -1140,6 +1152,7 @@ namespace WaterTrans.GlyphLoader
             ReadGPOS(reader);
             ReadCFF(reader);
             ReadGLYF(reader);
+            ReadNAME(reader);
             CalcGlyphMetrics();
             BuildGSUBFeatureRecord();
             BuildGPOSFeatureRecord();

--- a/src/WaterTrans.GlyphLoader/WaterTrans.GlyphLoader.csproj
+++ b/src/WaterTrans.GlyphLoader/WaterTrans.GlyphLoader.csproj
@@ -33,6 +33,7 @@ In WebAssembly environment, it can be used for application development using gly
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. The class of _TypefaceReader_ add _ReadString_ method to support read character strings.
2. The class of _Typeface_ add _tableOfNAME_ variable, which is type of _TableOfNAME_.
3. The class of _Typeface_ add _ReadNAME_ method to support read the table of NAME, and called in the method of _ReadCFFCharString_.
4. Add new classes, contains: _TableOfNAME_, _NameRecord_, and _NameEncoding_. Add new enum, contains: _PlatformID_.