### PR TITLE
Fix issue with accessing elements from empty array

### DIFF
--- a/src/WaterTrans.GlyphLoader/Internal/TableOfCMAP.cs
+++ b/src/WaterTrans.GlyphLoader/Internal/TableOfCMAP.cs
@@ -302,6 +302,11 @@ namespace WaterTrans.GlyphLoader.Internal
                     sorted.Add(8, record.GlyphMap);
                     continue;
                 }
+                if (record.PlatformID == 3 && record.EncodingID == 0)
+                {
+                    sorted.Add(9, record.GlyphMap);
+                    continue;
+                }
             }
 
             _glyphMap = sorted.Values.ToArray()[0];


### PR DESCRIPTION
I encountered an error while working with TrueType fonts related to conditional symbol fonts in the GIS domain. The library was throwing System.IndexOutOfRangeException. To address this issue, I debugged the code and added a missing check to prevent accessing elements from an empty array.